### PR TITLE
Safety improvements in OrganizeExtensions

### DIFF
--- a/demo/src/Language/Haskell/Tools/ASTDebug/Instances.hs
+++ b/demo/src/Language/Haskell/Tools/ASTDebug/Instances.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleContexts
            , FlexibleInstances
            , MultiParamTypeClasses
-           , StandaloneDeriving
-           , DeriveGeneric
            , UndecidableInstances
            , TypeFamilies
            #-}

--- a/demo/src/Language/Haskell/Tools/Demo.hs
+++ b/demo/src/Language/Haskell/Tools/Demo.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings
            , DeriveGeneric
            , TypeApplications
-           , TupleSections
            , ScopedTypeVariables
            , LambdaCase
            , TemplateHaskell

--- a/demo/test/Main.hs
+++ b/demo/test/Main.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE StandaloneDeriving, LambdaCase #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module Main where
 
 import Control.Concurrent (killThread, forkIO)

--- a/src/ast/Language/Haskell/Tools/AST/Ann.hs
+++ b/src/ast/Language/Haskell/Tools/AST/Ann.hs
@@ -10,7 +10,6 @@
            , AllowAmbiguousTypes
            , TypeApplications
            , ScopedTypeVariables
-           , PatternSynonyms
            , ConstraintKinds
            #-}
 -- | Parts of AST representation for keeping extra data

--- a/src/ast/Language/Haskell/Tools/AST/Helpers.hs
+++ b/src/ast/Language/Haskell/Tools/AST/Helpers.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleContexts
-           , LambdaCase
            , RankNTypes
            , ScopedTypeVariables
            , TypeFamilies

--- a/src/backend-ghc/Language/Haskell/Tools/BackendGHC/GHCUtils.hs
+++ b/src/backend-ghc/Language/Haskell/Tools/BackendGHC/GHCUtils.hs
@@ -2,7 +2,6 @@
            , TypeSynonymInstances
            , FlexibleInstances
            , ScopedTypeVariables
-           , ViewPatterns
            , LambdaCase
            , RecordWildCards
            , FlexibleContexts

--- a/src/backend-ghc/Language/Haskell/Tools/BackendGHC/Monad.hs
+++ b/src/backend-ghc/Language/Haskell/Tools/BackendGHC/Monad.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TupleSections #-}
+
 -- | The transformation monad carries the necessary information that is passed top-down
 -- during the conversion from GHC AST to our representation.
 module Language.Haskell.Tools.BackendGHC.Monad where

--- a/src/backend-ghc/Language/Haskell/Tools/BackendGHC/Names.hs
+++ b/src/backend-ghc/Language/Haskell/Tools/BackendGHC/Names.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE LambdaCase
-           , TupleSections
-           , TypeFamilies
+{-# LANGUAGE TypeFamilies
            , FlexibleInstances
            , FlexibleContexts
            , TypeSynonymInstances

--- a/src/backend-ghc/Language/Haskell/Tools/BackendGHC/Patterns.hs
+++ b/src/backend-ghc/Language/Haskell/Tools/BackendGHC/Patterns.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE LambdaCase
-           , ViewPatterns
+{-# LANGUAGE ViewPatterns
            , ScopedTypeVariables
            , AllowAmbiguousTypes
            #-}

--- a/src/backend-ghc/Language/Haskell/Tools/BackendGHC/TH.hs
+++ b/src/backend-ghc/Language/Haskell/Tools/BackendGHC/TH.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
+
 -- | Functions that convert the Template-Haskell-related elements of the GHC AST to corresponding elements in the Haskell-tools AST representation
 module Language.Haskell.Tools.BackendGHC.TH where
 

--- a/src/backend-ghc/Language/Haskell/Tools/BackendGHC/Types.hs
+++ b/src/backend-ghc/Language/Haskell/Tools/BackendGHC/Types.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE LambdaCase
-           , ViewPatterns
+{-# LANGUAGE ViewPatterns
            , ScopedTypeVariables
            #-}
 -- | Functions that convert the type-related elements of the GHC AST to corresponding elements in the Haskell-tools AST representation

--- a/src/backend-ghc/Language/Haskell/Tools/BackendGHC/Utils.hs
+++ b/src/backend-ghc/Language/Haskell/Tools/BackendGHC/Utils.hs
@@ -8,10 +8,6 @@
            , AllowAmbiguousTypes
            , TypeApplications
            , TypeFamilies
-           , BangPatterns
-           , StandaloneDeriving
-           , DeriveGeneric
-           , DeriveAnyClass
            #-}
 module Language.Haskell.Tools.BackendGHC.Utils where
 

--- a/src/builtin-refactorings/Language/Haskell/Tools/Refactor/Builtin.hs
+++ b/src/builtin-refactorings/Language/Haskell/Tools/Refactor/Builtin.hs
@@ -9,7 +9,7 @@ import Language.Haskell.Tools.Refactor.Builtin.GenerateTypeSignature (GenerateSi
 import Language.Haskell.Tools.Refactor.Builtin.InlineBinding (inlineBindingRefactoring)
 import Language.Haskell.Tools.Refactor.Builtin.OrganizeImports (OrganizeImportsDomain, organizeImportsRefactoring, projectOrganizeImportsRefactoring)
 import Language.Haskell.Tools.Refactor.Builtin.RenameDefinition (DomainRenameDefinition, renameDefinitionRefactoring)
-import Language.Haskell.Tools.Refactor.Builtin.OrganizeExtensions (OrganizeExtensionsDomain, organizeExtensionsRefactoring)
+import Language.Haskell.Tools.Refactor.Builtin.OrganizeExtensions (OrganizeExtensionsDomain, organizeExtensionsRefactoring, projectOrganizeExtensionsRefactoring)
 
 builtinRefactorings :: ( DomGenerateExports dom, OrganizeImportsDomain dom
                        , DomainRenameDefinition dom, ExtractBindingDomain dom
@@ -25,4 +25,5 @@ builtinRefactorings
     , floatOutRefactoring
     , extractBindingRefactoring
     , organizeExtensionsRefactoring
+    , projectOrganizeExtensionsRefactoring
     ]

--- a/src/builtin-refactorings/Language/Haskell/Tools/Refactor/Builtin/FloatOut.hs
+++ b/src/builtin-refactorings/Language/Haskell/Tools/Refactor/Builtin/FloatOut.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE LambdaCase
            , ConstraintKinds
            , FlexibleContexts
-           , ViewPatterns
            , TypeApplications
            , ScopedTypeVariables
            , TypeFamilies

--- a/src/builtin-refactorings/Language/Haskell/Tools/Refactor/Builtin/OrganizeExtensions.hs
+++ b/src/builtin-refactorings/Language/Haskell/Tools/Refactor/Builtin/OrganizeExtensions.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE FlexibleContexts,
+{-# LANGUAGE TupleSections,
              TypeFamilies,
              RankNTypes,
-             ConstraintKinds
+             ConstraintKinds,
+             FlexibleContexts,
+             LambdaCase
              #-}
-
 module Language.Haskell.Tools.Refactor.Builtin.OrganizeExtensions
   ( module Language.Haskell.Tools.Refactor.Builtin.OrganizeExtensions
   , module Language.Haskell.Tools.Refactor.Builtin.ExtensionOrganizer.ExtMonad
@@ -17,9 +18,10 @@ import Language.Haskell.Tools.Refactor.Utils.Extensions (expandExtension)
 
 import GHC
 
+import Data.Maybe
 import Data.Char
 import qualified Data.Map.Strict as SMap
-import Control.Reference ((&), (.=), (^?))
+import Control.Reference
 
 --import Debug.Trace (traceShow)
 
@@ -37,36 +39,43 @@ type OrganizeExtensionsDomain dom = (HasModuleInfo dom, ExtDomain dom)
 organizeExtensionsRefactoring :: OrganizeExtensionsDomain dom => RefactoringChoice dom
 organizeExtensionsRefactoring = ModuleRefactoring "OrganizeExtensions" (localRefactoring organizeExtensions)
 
+projectOrganizeExtensionsRefactoring :: OrganizeExtensionsDomain dom => RefactoringChoice dom
+projectOrganizeExtensionsRefactoring = ProjectRefactoring "ProjectOrganizeExtensions" projectOrganizeExtensions
+
+projectOrganizeExtensions :: forall dom . OrganizeExtensionsDomain dom => ProjectRefactoring dom
+projectOrganizeExtensions mods
+  = mapM (\(k, m) -> ContentChanged . (k,) <$> localRefactoringRes id m (organizeExtensions m)) mods
 
 tryOut :: String -> String -> IO ()
 tryOut = tryRefactor (localRefactoring . const organizeExtensions)
 
-
 organizeExtensions :: ExtDomain dom => LocalRefactoring dom
-organizeExtensions = \moduleAST -> do
+organizeExtensions moduleAST = do
   exts <- liftGhc $ collectExtensions moduleAST
   let exts'      = calcExts exts
-      newPragmas = [mkLanguagePragma . map show $ exts']
-  return $ (filePragmas & annListElems .= newPragmas) moduleAST
+      isRedundant e = (e ^. langExt) `notElem` map show exts' 
+                        && (e ^. langExt) `elem` fullyHandledExtensions
+  
+  -- remove unused extensions (only those that are fully handled)
+  filePragmas & annList & lpPragmas !~ filterListSt (not . isRedundant)
+        -- remove empty {-# LANGUAGE #-} pragmas
+    >=> filePragmas !~ filterListSt (\case LanguagePragma (AnnList []) -> False; _ -> True)
+    $ moduleAST
   where isLVar (LVar _) = True
         isLVar _        = False
 
         calcExts :: ExtMap -> [Extension]
         calcExts logRels
           | ks <- SMap.keys logRels
-          , all isLVar ks = map (\(LVar x) -> x) . SMap.keys $ logRels
+          , all isLVar ks 
+          = map (\(LVar x) -> x) . SMap.keys $ logRels
           | otherwise     = []
-
-        -- xs :: [(k, [v])]
-        -- printExts xs = forM_ xs (\(ext, loc) -> do
-        --                  traceShow ext $ return ()
-        --                  forM loc (\l ->
-        --                    traceShow l $ return ()
-        --                    )
-        --                  )
-
-
-
+          
+        fullyHandledExtensions :: [String]
+        fullyHandledExtensions 
+          = [ "RecordWildCards", "TemplateHaskell", "BangPatterns", "PatternSynonyms"
+            , "TupleSections", "LambdaCase", "QuasiQuotes", "ViewPatterns", "MagicHash"
+            , "UnboxedTuples" ]
 
 collectExtensions :: ExtDomain dom =>
                      UnnamedModule dom ->
@@ -83,19 +92,12 @@ collectDefaultExtensions = map toExt . getExtensions
   getExtensions :: UnnamedModule dom -> [String]
   getExtensions = flip (^?) (filePragmas & annList & lpPragmas & annList & langExt)
 
-  toExt :: String -> Extension
-  toExt = (read :: String -> Extension) . takeWhile isAlpha
+toExt :: String -> Extension
+toExt str = case map fst $ reads $ unregularExts $ takeWhile isAlpha str of
+              e:_ -> e
+              []  -> error $ "Extension '" ++ takeWhile isAlpha str ++ "' is not known."
 
-
-
-asd :: Num a => a -> a
-asd x = 2*x
-
-qwe :: Integer
-qwe = asd 5
-
-
-haha :: Integer
-haha = asd 7
-
-asdasdasd = 88
+unregularExts :: String -> String
+unregularExts "CPP" = "Cpp"
+unregularExts "NamedFieldPuns" = "RecordPuns"
+unregularExts e = e

--- a/src/builtin-refactorings/Language/Haskell/Tools/Refactor/Builtin/RenameDefinition.hs
+++ b/src/builtin-refactorings/Language/Haskell/Tools/Refactor/Builtin/RenameDefinition.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ScopedTypeVariables
-           , LambdaCase
            , MultiWayIf
            , TypeApplications
            , ConstraintKinds

--- a/src/builtin-refactorings/haskell-tools-builtin-refactorings.cabal
+++ b/src/builtin-refactorings/haskell-tools-builtin-refactorings.cabal
@@ -171,6 +171,5 @@ test-suite ht-extension-organizer-test
                      , haskell-tools-prettyprint >= 0.9  && < 0.10
                      , haskell-tools-refactor    >= 0.9  && < 0.10
                      , haskell-tools-builtin-refactorings
-                     , incremental-sat-solver    >= 0.1.8 && < 0.1.9
 
   default-language:    Haskell2010

--- a/src/cli/Language/Haskell/Tools/Refactor/CLI.hs
+++ b/src/cli/Language/Haskell/Tools/Refactor/CLI.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE LambdaCase
-           , TupleSections
-           , FlexibleContexts
+{-# LANGUAGE FlexibleContexts
            , TypeFamilies
-           , StandaloneDeriving
            , RecordWildCards
            , ScopedTypeVariables
            #-}

--- a/src/cli/benchmark/Main.hs
+++ b/src/cli/benchmark/Main.hs
@@ -1,7 +1,5 @@
 
-{-# LANGUAGE LambdaCase
-           , ViewPatterns
-           , TypeFamilies
+{-# LANGUAGE TypeFamilies
            , RecordWildCards
            , DeriveGeneric
            #-}

--- a/src/cli/test-stackage/Main.hs
+++ b/src/cli/test-stackage/Main.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase
            , TypeApplications
-           , TupleSections
            , ScopedTypeVariables
            #-}
 module Main where

--- a/src/daemon/Language/Haskell/Tools/Daemon.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables
            , OverloadedStrings
-           , DeriveGeneric
-           , LambdaCase
-           , TemplateHaskell
            , FlexibleContexts
            , MultiWayIf
            , TypeApplications

--- a/src/daemon/Language/Haskell/Tools/Daemon/GetModules.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/GetModules.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE TupleSections
            , NamedFieldPuns
            , LambdaCase
-           , TemplateHaskell
            , FlexibleContexts
            , TypeApplications
            , RankNTypes

--- a/src/daemon/Language/Haskell/Tools/Daemon/Session.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/Session.hs
@@ -1,10 +1,6 @@
-{-# LANGUAGE TemplateHaskell
-           , TupleSections
-           , TypeApplications
+{-# LANGUAGE TypeApplications
            , MultiWayIf
            , FlexibleContexts
-           , BangPatterns
-           , StandaloneDeriving
            #-}
 -- | Common operations for managing Daemon-tools sessions, for example loading whole packages or
 -- re-loading modules when they are changed. Maintains the state of the compilation with loaded

--- a/src/daemon/Language/Haskell/Tools/Daemon/Update.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/Update.hs
@@ -5,8 +5,6 @@
            , TypeFamilies
            , RecordWildCards
            , FlexibleContexts
-           , BangPatterns
-           , ViewPatterns
            , TupleSections
            #-}
 -- | Resolves how the daemon should react to individual requests from the client.

--- a/src/daemon/Language/Haskell/Tools/Daemon/Utils.hs
+++ b/src/daemon/Language/Haskell/Tools/Daemon/Utils.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE LambdaCase
-           , RankNTypes
+{-# LANGUAGE RankNTypes
            , FlexibleContexts
            #-}
 -- | Utility operations for the reprsentation of module collections.

--- a/src/debug/Language/Haskell/Tools/Debug/RangeDebug.hs
+++ b/src/debug/Language/Haskell/Tools/Debug/RangeDebug.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE TypeOperators
            , DefaultSignatures
-           , StandaloneDeriving
            , FlexibleContexts
            , FlexibleInstances
            , MultiParamTypeClasses

--- a/src/debug/Language/Haskell/Tools/Debug/RangeDebugInstances.hs
+++ b/src/debug/Language/Haskell/Tools/Debug/RangeDebugInstances.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleContexts
            , FlexibleInstances
            , MultiParamTypeClasses
-           , StandaloneDeriving
-           , DeriveGeneric
            , UndecidableInstances
            , TypeFamilies
            #-}

--- a/src/experimental-refactorings/test/Main.hs
+++ b/src/experimental-refactorings/test/Main.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE LambdaCase
-           , ViewPatterns
            , TypeFamilies
            #-}
 module Main where

--- a/src/prettyprint/Language/Haskell/Tools/PrettyPrint/Prepare/RangeTemplate.hs
+++ b/src/prettyprint/Language/Haskell/Tools/PrettyPrint/Prepare/RangeTemplate.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE TemplateHaskell
-           , DeriveDataTypeable
+{-# LANGUAGE DeriveDataTypeable
            , RecordWildCards
            , TypeFamilies
            , FlexibleInstances

--- a/src/prettyprint/Language/Haskell/Tools/PrettyPrint/Prepare/RangeTemplateToSourceTemplate.hs
+++ b/src/prettyprint/Language/Haskell/Tools/PrettyPrint/Prepare/RangeTemplateToSourceTemplate.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE LambdaCase
-           , FlexibleContexts
+{-# LANGUAGE FlexibleContexts
            #-}
 -- | This module converts range templates into source templates.
 -- Basically it reads the source file and attaches parts of the source file to the AST elements that have the range of the given source code fragment.

--- a/src/prettyprint/Language/Haskell/Tools/PrettyPrint/Prepare/RangeToRangeTemplate.hs
+++ b/src/prettyprint/Language/Haskell/Tools/PrettyPrint/Prepare/RangeToRangeTemplate.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ScopedTypeVariables
-           , LambdaCase
            , FlexibleContexts
            #-}
 -- | Transform a syntax tree with ranges to a syntax tree that has range templates. Cuts the ranges of children

--- a/src/prettyprint/Language/Haskell/Tools/PrettyPrint/RoseTree.hs
+++ b/src/prettyprint/Language/Haskell/Tools/PrettyPrint/RoseTree.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NamedFieldPuns
            , FlexibleContexts
            , LambdaCase
-           , DeriveFunctor
            , StandaloneDeriving
            #-}
 -- | A simpler representation of the original AST.

--- a/src/refactor/Language/Haskell/Tools/Refactor/Monad.hs
+++ b/src/refactor/Language/Haskell/Tools/Refactor/Monad.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE TypeSynonymInstances
            , FlexibleInstances
-           , DeriveFunctor
            , GeneralizedNewtypeDeriving
            #-}
 -- | Types and instances for monadic refactorings. The refactoring monad provides automatic

--- a/src/refactor/Language/Haskell/Tools/Refactor/Prepare.hs
+++ b/src/refactor/Language/Haskell/Tools/Refactor/Prepare.hs
@@ -1,13 +1,8 @@
-{-# LANGUAGE StandaloneDeriving
-           , DeriveGeneric
-           , LambdaCase
+{-# LANGUAGE LambdaCase
            , ScopedTypeVariables
-           , BangPatterns
            , MultiWayIf
            , FlexibleContexts
            , TypeFamilies
-           , TupleSections
-           , ViewPatterns
            #-}
 -- | Defines utility methods that prepare Haskell modules for refactoring
 module Language.Haskell.Tools.Refactor.Prepare where

--- a/src/refactor/Language/Haskell/Tools/Refactor/Representation.hs
+++ b/src/refactor/Language/Haskell/Tools/Refactor/Representation.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE RecordWildCards
-           , TypeSynonymInstances
+{-# LANGUAGE TypeSynonymInstances
            , FlexibleInstances
            , TemplateHaskell
            #-}

--- a/src/refactor/Language/Haskell/Tools/Refactor/Utils/Lists.hs
+++ b/src/refactor/Language/Haskell/Tools/Refactor/Utils/Lists.hs
@@ -111,3 +111,14 @@ zipWithSeparators (AnnListG (NodeInfo _ src) elems)
   | otherwise
   = zip (([], noSrcSpan) : seps ++ repeat (_2 .= noSrcSpan $ last seps)) elems
   where seps = src ^. srcTmpSeparators
+
+-- sortList :: Ord a => (Ann e dom -> a) -> AnnList e dom -> AnnList e dom
+-- sortList comp (AnnListG annot elems) 
+--   = AnnListG ( .- permuteList permute $ annot) sortedElems
+--   where (permute, sortedElems) = unzip (sortBy (comp . snd)) indElems
+--         indElems = zip [0..] elems
+-- 
+-- permuteList :: [Int] -> [a] -> [a]
+-- permuteList permute = map snd . sortBy fst . zip permute
+ 
+ 

--- a/src/refactor/Language/Haskell/Tools/Refactor/Utils/Monadic.hs
+++ b/src/refactor/Language/Haskell/Tools/Refactor/Utils/Monadic.hs
@@ -1,16 +1,9 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving
-           , TypeFamilies
-           , ViewPatterns
-           , StandaloneDeriving
-           , LambdaCase
+{-# LANGUAGE TypeFamilies
            , FlexibleInstances
            , FlexibleContexts
            , TypeSynonymInstances
            , MultiWayIf
-           , TemplateHaskell
-           , ViewPatterns
            , TypeApplications
-           , RecordWildCards
            #-}
 -- | Basic utilities and types for defining refactorings.
 module Language.Haskell.Tools.Refactor.Utils.Monadic where

--- a/src/rewrite/Language/Haskell/Tools/Rewrite/Create/Names.hs
+++ b/src/rewrite/Language/Haskell/Tools/Rewrite/Create/Names.hs
@@ -1,6 +1,5 @@
 -- | Generation of names for refactorings
 {-# LANGUAGE OverloadedStrings
-           , ViewPatterns
            , TypeFamilies
            #-}
 module Language.Haskell.Tools.Rewrite.Create.Names where


### PR DESCRIPTION
Removed unnecessary dependency. Improvements in applying the refactoring. Only apply the refactoring for extensions that can be safely removed. Applied Organize Extensions to the project.